### PR TITLE
added bug-i-dex backend functionality w/ per-user caught/uncaught states

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ build/Release
 node_modules/
 jspm_packages/
 
+# Uploaded bug photos (keep the directory via .gitkeep, ignore the contents)
+public/images/*
+!public/images/.gitkeep
+
 # Snowpack dependency directory (https://snowpack.dev/)
 web_modules/
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3208,6 +3208,7 @@
       "version": "8.8.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.8.0.tgz",
       "integrity": "sha512-UXYN0ziKj+AeNNP7VDMwrehpACThH7LUl/p8TDFpEUuSejCUIwGSfxpHsPvtM6/WXFy6SU4E5RG4IJV/TZAGjw==",
+      "peer": true,
       "dependencies": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ const pgp = require('pg-promise')();
 // setup image storage
 const multer = require("multer");
 const storage = multer.diskStorage({
-  destination: function(req, fule, cb){
+  destination: function(req, file, cb){
     cb(null, 'public/images/');
   },
   filename: function(req, file, cb){
@@ -38,7 +38,7 @@ const upload = multer({
   limits: {fileSize: maxSize},
   fileFilter: function(req, file, cb){
     const filetypes = /jpeg|jpg|png|webp/;
-    const mimetype = filetypess.test(file.mimetype);
+    const mimetype = filetypes.test(file.mimetype);
     const extname = filetypes.test(path.extname(file.originalname).toLowerCase());
     if(mimetype && extname){
       return cb(null, true);
@@ -155,7 +155,21 @@ app.get('/api/users', async (req, res) => {
 
 app.get('/bug-i-dex', async (req, res) => {
   try {
-    const bugs = await db.any('SELECT * FROM bug_info ORDER BY bug_id ASC');
+    const username = req.session.user ? req.session.user.username : '';
+    const bugs = await db.any(`
+      SELECT b.bug_id,
+             b.common_name,
+             b.genus,
+             b.color,
+             b.image_url,
+             EXISTS (
+               SELECT 1 FROM posts p
+               JOIN user_to_post utp ON utp.post_id = p.id
+               WHERE p.bug_id = b.bug_id AND utp.user_id = $1
+             ) AS caught
+      FROM bug_info b
+      ORDER BY b.bug_id ASC
+    `, [username]);
 
     res.render('pages/bug-i-dex', {
       title: 'bug-i-dex',
@@ -174,46 +188,35 @@ app.get('/bug-i-dex', async (req, res) => {
 app.use(express.urlencoded({ extended: true }));
 
 //render submit page
-app.get('/submit',  isAuthenticated,(req, res) => {
-
+app.get('/submit', isAuthenticated, async (req, res) => {
   try {
-    res.render('pages/submit', { title: 'Submit'});
+    const bugs = await db.any('SELECT bug_id, common_name, genus FROM bug_info ORDER BY common_name ASC');
+    res.render('pages/submit', { title: 'Submit', bugs });
   } catch (error) {
-    console.error('you must register first', error);
-    res.redirect('/register')
+    console.error('Error loading species list:', error);
+    res.redirect('/home');
   }
 });
 
 // extract from page:
 app.post('/submit', upload, async (req, res) => {
   try {
-    const { common_name, genus, color, latitude, longitude, comments } = req.body;
+    const { bug_id, latitude, longitude, comments } = req.body;
 
-    // 1️ Insert into bug_info and return bug_id
-    const bug = await db.one(
-      `INSERT INTO bug_info (common_name, genus, color)
-       VALUES ($1, $2, $3)
-       RETURNING bug_id`,
-      [common_name, genus, color]
-    );
-
-    const bugId = bug.bug_id;
-
-    // 2 Insert into posts using POINT
-       const post = await db.one(
+    const post = await db.one(
       `INSERT INTO posts (coords, bug_id, comments)
-      VALUES (POINT($1, $2), $3, $4)
-      RETURNING id`,
-      [longitude, latitude, bugId, comments]// ⚠️ order matters: (x=lng, y=lat)
+       VALUES (POINT($1, $2), $3, $4)
+       RETURNING id`,
+      [longitude, latitude, bug_id, comments]
     );
 
     await db.none(
       `INSERT INTO user_to_post (user_id, post_id)
        VALUES ($1, $2)`,
-      [req.session.user.username, post.id] // username is correct for your schema
+      [req.session.user.username, post.id]
     );
 
-    res.redirect('/map');
+    res.redirect('/bug-i-dex');
 
   } catch (error) {
     console.error('Error inputting bug:', error);

--- a/src/init_data/03_bug_info.sql
+++ b/src/init_data/03_bug_info.sql
@@ -35,7 +35,8 @@ CREATE TABLE public.bug_info (
     genus text NOT NULL,
     flying boolean DEFAULT false NOT NULL,
     limb_count smallint DEFAULT 0 NOT NULL,
-    color text NOT NULL
+    color text NOT NULL,
+    image_url text
 );
 
 
@@ -99,27 +100,27 @@ ALTER TABLE ONLY public.bug_info
 
 \unrestrict boS2xgh1UBCGnzjPpHTfnrD1TQSxc0ZOLJwrlffBXY26bkCXo5sCczhAYpNaepj
 
-INSERT INTO public.bug_info (common_name, genus, flying, limb_count, color) VALUES
-('Ant', 'Formica', false, 6, 'Black'),
-('Mosquito', 'Culex', true, 6, 'Gray'),
-('House Fly', 'Musca', true, 6, 'Black'),
-('Cockroach', 'Periplaneta', false, 6, 'Brown'),
-('Grasshopper', 'Melanoplus', true, 6, 'Green'),
-('Aphid', 'Aphis', false, 6, 'Green'),
-('Beetle', 'Coleoptera', true, 6, 'Brown'),
-('Stink Bug', 'Halyomorpha', true, 6, 'Brown'),
-('Yellowjacket', 'Vespula', true, 6, 'Yellow/Black'),
-('Wasp', 'Polistes', true, 6, 'Yellow/Black'),
-('Hornet', 'Vespa', true, 6, 'Brown/Yellow'),
-('Butterfly', 'Danaus', true, 6, 'Orange/Black'),
-('Moth', 'Noctuidae', true, 6, 'Brown'),
-('Caterpillar', 'Lepidoptera', false, 6, 'Green'),
-('Black Widow Spider', 'Latrodectus', false, 8, 'Black'),
-('Wolf Spider', 'Lycosidae', false, 8, 'Brown'),
-('Tick', 'Ixodes', false, 8, 'Brown'),
-('Earwig', 'Dermaptera', false, 6, 'Brown'),
-('Dragonfly', 'Anisoptera', true, 6, 'Blue/Green'),
-('Fire Ant', 'Solenopsis', false, 6, 'Red');
+INSERT INTO public.bug_info (common_name, genus, flying, limb_count, color, image_url) VALUES
+('Ant', 'Formica', false, 6, 'Black', 'https://loremflickr.com/400/300/ant?lock=1'),
+('Mosquito', 'Culex', true, 6, 'Gray', 'https://loremflickr.com/400/300/mosquito?lock=2'),
+('House Fly', 'Musca', true, 6, 'Black', 'https://loremflickr.com/400/300/housefly?lock=3'),
+('Cockroach', 'Periplaneta', false, 6, 'Brown', 'https://loremflickr.com/400/300/cockroach?lock=4'),
+('Grasshopper', 'Melanoplus', true, 6, 'Green', 'https://loremflickr.com/400/300/grasshopper?lock=5'),
+('Aphid', 'Aphis', false, 6, 'Green', 'https://loremflickr.com/400/300/aphid?lock=6'),
+('Beetle', 'Coleoptera', true, 6, 'Brown', 'https://loremflickr.com/400/300/beetle?lock=7'),
+('Stink Bug', 'Halyomorpha', true, 6, 'Brown', 'https://loremflickr.com/400/300/stinkbug?lock=8'),
+('Yellowjacket', 'Vespula', true, 6, 'Yellow/Black', 'https://loremflickr.com/400/300/yellowjacket?lock=9'),
+('Wasp', 'Polistes', true, 6, 'Yellow/Black', 'https://loremflickr.com/400/300/wasp?lock=10'),
+('Hornet', 'Vespa', true, 6, 'Brown/Yellow', 'https://loremflickr.com/400/300/hornet?lock=11'),
+('Butterfly', 'Danaus', true, 6, 'Orange/Black', 'https://loremflickr.com/400/300/butterfly?lock=12'),
+('Moth', 'Noctuidae', true, 6, 'Brown', 'https://loremflickr.com/400/300/moth?lock=13'),
+('Caterpillar', 'Lepidoptera', false, 6, 'Green', 'https://loremflickr.com/400/300/caterpillar?lock=14'),
+('Black Widow Spider', 'Latrodectus', false, 8, 'Black', 'https://loremflickr.com/400/300/blackwidow?lock=15'),
+('Wolf Spider', 'Lycosidae', false, 8, 'Brown', 'https://loremflickr.com/400/300/wolfspider?lock=16'),
+('Tick', 'Ixodes', false, 8, 'Brown', 'https://loremflickr.com/400/300/tick?lock=17'),
+('Earwig', 'Dermaptera', false, 6, 'Brown', 'https://loremflickr.com/400/300/earwig?lock=18'),
+('Dragonfly', 'Anisoptera', true, 6, 'Blue/Green', 'https://loremflickr.com/400/300/dragonfly?lock=19'),
+('Fire Ant', 'Solenopsis', false, 6, 'Red', 'https://loremflickr.com/400/300/fireant?lock=20');
 
 CREATE INDEX IF NOT EXISTS idx_bug_info_common_name ON public.bug_info (common_name);
 CREATE INDEX IF NOT EXISTS idx_bug_info_genus ON public.bug_info (genus);

--- a/src/resources/css/bug-i-dex.css
+++ b/src/resources/css/bug-i-dex.css
@@ -1,0 +1,47 @@
+.dex-title {
+    color: rgb(72, 133, 72);
+    margin: 1rem 0 1.5rem;
+    text-align: center;
+}
+
+.bug-card {
+    border-radius: 16px;
+    box-shadow: 0 8px 22px rgba(0, 0, 0, 0.08);
+    overflow: hidden;
+    border: none;
+}
+
+.bug-card .bug-image {
+    width: 100%;
+    height: 180px;
+    object-fit: cover;
+    display: block;
+}
+
+.bug-card--caught {
+    background: #ffffff;
+}
+
+.bug-card--caught .card-title {
+    color: rgb(72, 133, 72);
+    margin-bottom: 0.25rem;
+}
+
+.bug-card--uncaught {
+    background: #e2e6e2;
+}
+
+.bug-card--uncaught .bug-image--placeholder {
+    height: 180px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 4rem;
+    font-weight: bold;
+    color: #8a8a8a;
+    background: #cfd4cf;
+}
+
+.bug-card--uncaught .card-title {
+    color: #8a8a8a;
+}

--- a/src/views/pages/bug-i-dex.hbs
+++ b/src/views/pages/bug-i-dex.hbs
@@ -1,35 +1,27 @@
- <div class="row">
+<link rel="stylesheet" href="/css/bug-i-dex.css">
 
-{{#unless bugs.length}}
-<div class = col-md-4>
-  <p id= "nobugserror" class = "p-3 mb-3"> no bugs have been submitted at this time</p>
-  </div>
-{{/unless}}
-
+<div class="container">
+  <h1 class="dex-title">Bug-i-dex</h1>
+  <div class="row">
     {{#each bugs}}
       <div class="col-md-4 mb-4">
-
-        <div class="card h-100 shadow-sm">
-
-          <div class="card-body">
-            <h5 class="card-title">{{common_name}}</h5>
-
-            <h6 class="card-subtitle mb-2 text-muted">
-              {{genus}}
-            </h6>
-
-            <p class="card-text">
-              <strong>Color:</strong> {{color}} <br>
-              <strong>Lat:</strong> {{latitude}} <br>
-              <strong>Lng:</strong> {{longitude}}
-            </p>
-
+        {{#if caught}}
+          <div class="card h-100 bug-card bug-card--caught">
+            <img src="{{image_url}}" alt="{{common_name}}" class="bug-image">
+            <div class="card-body">
+              <h5 class="card-title">#{{bug_id}} {{common_name}}</h5>
+              <p class="card-text text-muted"><em>{{genus}}</em></p>
+            </div>
           </div>
-
-        </div>
-
+        {{else}}
+          <div class="card h-100 bug-card bug-card--uncaught">
+            <div class="bug-image bug-image--placeholder">?</div>
+            <div class="card-body">
+              <h5 class="card-title">#{{bug_id}} ???</h5>
+            </div>
+          </div>
+        {{/if}}
       </div>
     {{/each}}
-
   </div>
 </div>

--- a/src/views/pages/submit.hbs
+++ b/src/views/pages/submit.hbs
@@ -1,4 +1,4 @@
-<h2 class = "container mb-3">SUMBIT A BUG</h2>
+<h2 class = "container mb-3">SUBMIT A BUG</h2>
 
 <!-- bug_id bigint NOT NULL,
     common_name text NOT NULL,
@@ -10,41 +10,16 @@
 -->
 
 <div class="container p-4">
-<form id="submit" action = "/submit" method = "POST">
+<form id="submit" action = "/submit" method = "POST" enctype="multipart/form-data">
 
 
-    <div class="mb-3"> 
-        <label for="Common_Name" class="form-label"> Bug Common Name </label>
-        <input
-         type="text" 
-         class="form-control" 
-         id="Bug Common Name" 
-         aria-describedby="Bug Common Name" 
-         placeholder= "Bug Common Name" 
-         name="common_name" >
-    </div>
-
-    <div class="mb-3"> 
-        <label for="genus" class="form-label"> genus </label>
-        <input
-         type="text" 
-         class="form-control" 
-         id="Genus" 
-         aria-describedby="Genus" 
-         placeholder= "genus" 
-         name="genus" >
-    </div>
-
-
-     <div class="mb-3"> 
-        <label for="color" class="form-label"> color </label>
-        <input
-         type="text" 
-         class="form-control" 
-         id="Color" 
-         aria-describedby="Color" 
-         placeholder= "Color" 
-         name="color" >
+    <div class="mb-3">
+        <label for="bug_id" class="form-label"> Species </label>
+        <select class="form-control" id="bug_id" name="bug_id" required>
+            {{#each bugs}}
+                <option value="{{bug_id}}">{{common_name}} ({{genus}})</option>
+            {{/each}}
+        </select>
     </div>
 
 <button type="button" id="locationButton" class="btn btn-primary mb-3" style="background-color:green; border-color:green">
@@ -77,7 +52,10 @@
 {{!-- 
  Check if geolocation is supported by the browser --}}
 
-    <input type="image" name="image" accept="image" />
+    <div class="mb-3">
+        <label for="bugImage" class="form-label"> Photo </label>
+        <input type="file" class="form-control" id="bugImage" name="bugImage" accept="image/*" />
+    </div>
 
     <button type="submit" class="btn btn-primary" style="background-color:green; border-color:green">Submit</button>
 </form>


### PR DESCRIPTION
## summary

turns the bug-i-dex page into a functional pokedex-style tracker. new users (or logged-out visitors) see all 20 boulder spcies greyed out with "?" placeholders. once a user submits a bug via '/submit' , that species unlocks on their bug-i-dex in color with name + image. 

## notes

added **new column to db "bug_info" ... postgres init scripts only run on a fresh volume, so you need to wipe and re-init ONE TIME:**

```
docker compose down -v
docker compose up
```

^ Do this before testing this branch ^

## files changed

src/index.js
- bug-i-dex route
- /submit POST, GET

src/views/pages/bug-i-dex.hbs
- replaced with broken template
- links new /css/bug-i-dex.css

src/resources/css/bug-i-dex.css
- added caught and uncaught styling

public/images/
- created dir with a .gitkeep
- added rule so uploaded test photos don't get committed but dir stays tracked

## test plan
  - [ ] Run `docker compose down -v && docker compose up`                          
  - [ ] Visit `/bug-i-dex` logged out → all 20 cards greyed with `?`
  - [ ] Register a new account → `/bug-i-dex` still all greyed                     
  - [ ] `/submit` → verify dropdown lists all 20 species alphabetically, file input
   is `type="file"`, form has `enctype="multipart/form-data"`                      
  - [ ] Submit a species (e.g. Ant) with lat/lng → redirects to `/bug-i-dex` with  
  that species unlocked in color                                                   
  - [ ] Other 19 cards still greyed                                              
  - [ ] Log out → all greyed again (confirms per-user state)                       
  - [ ] Log in as a different account → all greyed (confirms isolation)  

note: tested end-to-end on @trentclat local env ... looks good. **verify before accepting PR**
